### PR TITLE
Release Candidate No. 1 (v1.0.0-rc-0)

### DIFF
--- a/.github/workflows/publish_prerelease.yml
+++ b/.github/workflows/publish_prerelease.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-dotnet@v4
 
       - name: Run Tauri Build (Windows & Linux)
-        if: matrix.platform != 'macos-latest'
+        if: matrix.platform != 'self-hosted'
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Release Candidate No. 1 (v1.0.0-rc-0)

## All core functionality is implemented.

We can finally introduce the first release candidate for building automatically. There might be bugs though, so we should be careful what we are looking at.

Last commit to main branch: d5ef378d007c5299ac41856757f59b4d61adfc07.

(Now with fixed GA build files.)